### PR TITLE
feat: update config to move proof timeout into per zkvm config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,6 @@ el_endpoint = "http://localhost:8545"
 # Timeout for witness fetching in seconds (default: 12)
 # witness_timeout_secs = 12
 
-# Timeout for proof generation in seconds (default: 12)
-# proof_timeout_secs = 12
-
 # LRU cache size for completed proofs (default: 128)
 # proof_cache_size = 128
 
@@ -73,16 +70,20 @@ el_endpoint = "http://localhost:8545"
 [[zkvm]]
 kind = "ere"
 proof_type = "ethrex-zisk"
+
+# Timeout for proof generation in seconds (default: 12)
+# proof_timeout_secs = 12
+
+# Endpoint of the Ere server
 endpoint = "http://ere-server:3000"
 
 # Mock zkVMs (in-process, for testing without Docker/GPU)
 
-# Fixed proving time
+# Fixed proving time (default)
 [[zkvm]]
 kind = "mock"
 proof_type = "reth-sp1"
-mock_proving_time = { kind = "constant", ms = 3000 }
-mock_proof_size = 1024
+mock_proving_time = { kind = "constant", ms = 6000 }
 
 # Random proving time uniformly sampled from [min_ms, max_ms]
 [[zkvm]]

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -16,7 +16,7 @@ const DEFAULT_WITNESS_TIMEOUT_SECS: u64 = 12;
 const DEFAULT_PROOF_TIMEOUT_SECS: u64 = 12;
 const DEFAULT_PROOF_CACHE_SIZE: usize = 128;
 const DEFAULT_WITNESS_CACHE_SIZE: usize = 128;
-const DEFAULT_MOCK_PROOF_SIZE: u64 = 1024;
+const DEFAULT_MOCK_PROOF_SIZE: u64 = 128 << 10;
 const DEFAULT_DASHBOARD_ENABLED: bool = false;
 const DEFAULT_DASHBOARD_RETENTION: usize = 256;
 
@@ -41,7 +41,7 @@ fn default_witness_cache_size() -> usize {
 }
 
 fn default_mock_proving_time() -> MockProvingTime {
-    MockProvingTime::Constant { ms: 3000 }
+    MockProvingTime::Constant { ms: 6000 }
 }
 
 fn default_mock_proof_size() -> u64 {
@@ -70,13 +70,10 @@ pub struct Config {
     /// Timeout in seconds for witness data (both pending-proof and fetch staleness).
     #[serde(default = "default_witness_timeout_secs")]
     pub witness_timeout_secs: u64,
-    /// Timeout in seconds for proof generation per zkVM worker.
-    #[serde(default = "default_proof_timeout_secs")]
-    pub proof_timeout_secs: u64,
-    /// Maximum number of completed proofs to keep in the LRU cache.
+    /// Number of blocks to keep in the completed proofs LRU cache.
     #[serde(default = "default_proof_cache_size")]
     pub proof_cache_size: usize,
-    /// Maximum number of execution witnesses to keep in the LRU cache.
+    /// Number of blocks to keep in the execution witness LRU cache.
     #[serde(default = "default_witness_cache_size")]
     pub witness_cache_size: usize,
     /// Dashboard feature configuration.
@@ -116,6 +113,19 @@ impl Config {
                 proof_types.insert(proof_type),
                 "duplicate proof_type: {proof_type}"
             );
+            match zkvm {
+                zkVMConfig::Ere {
+                    proof_timeout_secs, ..
+                }
+                | zkVMConfig::Mock {
+                    proof_timeout_secs, ..
+                } => {
+                    ensure!(
+                        *proof_timeout_secs > 0,
+                        "proof_timeout_secs must be > 0 for {proof_type}"
+                    );
+                }
+            }
             if let zkVMConfig::Mock {
                 mock_proving_time,
                 mock_proof_size,
@@ -165,15 +175,21 @@ pub enum MockProvingTime {
 pub enum zkVMConfig {
     /// Remote ere-server backend.
     Ere {
-        /// HTTP endpoint URL of the ere-server.
-        endpoint: String,
         /// Proof type.
         proof_type: ProofType,
+        /// Timeout in seconds for proof generation.
+        #[serde(default = "default_proof_timeout_secs")]
+        proof_timeout_secs: u64,
+        /// HTTP endpoint URL of the ere-server.
+        endpoint: String,
     },
     /// In-process mock backend for testing.
     Mock {
         /// Proof type.
         proof_type: ProofType,
+        /// Timeout in seconds for proof generation.
+        #[serde(default = "default_proof_timeout_secs")]
+        proof_timeout_secs: u64,
         /// Simulated proving time configuration.
         #[serde(default = "default_mock_proving_time")]
         mock_proving_time: MockProvingTime,
@@ -262,8 +278,9 @@ mod tests {
         assert!(matches!(
             config.zkvm[0],
             zkVMConfig::Mock {
-                mock_proving_time: MockProvingTime::Constant { ms: 3000 },
-                mock_proof_size: 1024,
+                proof_timeout_secs: 12,
+                mock_proving_time: MockProvingTime::Constant { ms: 6000 },
+                mock_proof_size: 131072,
                 ..
             }
         ));
@@ -328,6 +345,19 @@ mod tests {
             kind = "mock"
             proof_type = "reth-sp1"
             mock_proving_time = { kind = "random", min_ms = 1000, max_ms = 50 }
+        "#;
+        let config: Config = toml_edit::de::from_str(toml).unwrap();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_zero_proof_timeout_secs_rejected() {
+        let toml = r#"
+            el_endpoint = "http://localhost:8545"
+            [[zkvm]]
+            kind = "mock"
+            proof_type = "reth-sp1"
+            proof_timeout_secs = 0
         "#;
         let config: Config = toml_edit::de::from_str(toml).unwrap();
         assert!(config.validate().is_err());

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -125,6 +125,7 @@ pub(crate) mod tests {
         let proof_type = ProofType::RethZisk;
         let mock_config = zkVMConfig::Mock {
             proof_type,
+            proof_timeout_secs: 12,
             mock_proving_time: MockProvingTime::Constant { ms: 10 },
             mock_proof_size: 64,
             mock_failure: false,

--- a/crates/server/src/proof.rs
+++ b/crates/server/src/proof.rs
@@ -65,7 +65,6 @@ pub(crate) struct ProofService {
     proof_event_tx: broadcast::Sender<ProofEvent>,
     witness_service_tx: mpsc::Sender<WitnessServiceMessage>,
     dashboard_service_tx: mpsc::Sender<DashboardMessage>,
-    proof_timeout: Duration,
     pending: HashMap<Hash256, PendingRequest>,
     requested: HashSet<(Hash256, ProofType)>,
 }
@@ -78,7 +77,6 @@ impl ProofService {
         proof_event_tx: broadcast::Sender<ProofEvent>,
         witness_service_tx: mpsc::Sender<WitnessServiceMessage>,
         dashboard_service_tx: mpsc::Sender<DashboardMessage>,
-        proof_timeout: Duration,
     ) -> Self {
         Self {
             chain_config,
@@ -86,7 +84,6 @@ impl ProofService {
             proof_event_tx,
             witness_service_tx,
             dashboard_service_tx,
-            proof_timeout,
             pending: HashMap::new(),
             requested: HashSet::new(),
         }
@@ -170,8 +167,8 @@ impl ProofService {
                     proof_type,
                     FailureReason::ProvingTimeout,
                     format!(
-                        "proving timed out after {} seconds",
-                        self.proof_timeout.as_secs()
+                        "proving timed out after {:.02} seconds",
+                        duration.as_secs_f64()
                     ),
                     duration,
                 );

--- a/crates/server/src/proof/worker.rs
+++ b/crates/server/src/proof/worker.rs
@@ -52,9 +52,9 @@ pub(crate) async fn run_worker(
     mut worker_input_rx: mpsc::Receiver<WorkerInput>,
     worker_output_tx: mpsc::Sender<WorkerOutput>,
     dashboard_service_tx: mpsc::Sender<DashboardMessage>,
-    proof_timeout: Duration,
 ) {
     let proof_type = zkvm.proof_type();
+    let proof_timeout = zkvm.proof_timeout();
     let otel_name = format!("prove/{proof_type}");
 
     info!(%proof_type, "zkvm worker started");

--- a/crates/server/src/proof/zkvm.rs
+++ b/crates/server/src/proof/zkvm.rs
@@ -46,6 +46,8 @@ pub(crate) enum zkVMInstance {
     Ere {
         /// Proof type identifier (e.g. `"reth-sp1"`).
         proof_type: ProofType,
+        /// Timeout for proof generation.
+        proof_timeout: Duration,
         /// Client of external Ere server.
         client: Arc<zkVMClient>,
     },
@@ -53,6 +55,8 @@ pub(crate) enum zkVMInstance {
     Mock {
         /// Proof type identifier (e.g. `"reth-sp1"`).
         proof_type: ProofType,
+        /// Timeout for proof generation.
+        proof_timeout: Duration,
         /// Mock zkVM implementation.
         vm: MockzkVM,
     },
@@ -63,8 +67,9 @@ impl zkVMInstance {
     pub(crate) async fn new(config: &zkVMConfig) -> anyhow::Result<Self> {
         match config {
             zkVMConfig::Ere {
-                endpoint,
                 proof_type,
+                proof_timeout_secs,
+                endpoint,
             } => {
                 let endpoint_url = Url::parse(endpoint)
                     .with_context(|| format!("failed to parse endpoint URL: {endpoint}"))?;
@@ -81,16 +86,19 @@ impl zkVMInstance {
                 };
                 Ok(Self::Ere {
                     proof_type: *proof_type,
+                    proof_timeout: Duration::from_secs(*proof_timeout_secs),
                     client: Arc::new(client),
                 })
             }
             zkVMConfig::Mock {
                 proof_type,
+                proof_timeout_secs,
                 mock_proving_time,
                 mock_proof_size,
                 mock_failure,
             } => Ok(Self::Mock {
                 proof_type: *proof_type,
+                proof_timeout: Duration::from_secs(*proof_timeout_secs),
                 vm: MockzkVM::new(
                     proof_type.el_kind(),
                     mock_proving_time.clone(),
@@ -163,6 +171,13 @@ impl zkVMInstance {
     pub(crate) fn proof_type(&self) -> ProofType {
         match self {
             Self::Ere { proof_type, .. } | Self::Mock { proof_type, .. } => *proof_type,
+        }
+    }
+
+    /// Returns the proof timeout for this instance.
+    pub(crate) fn proof_timeout(&self) -> Duration {
+        match self {
+            Self::Ere { proof_timeout, .. } | Self::Mock { proof_timeout, .. } => *proof_timeout,
         }
     }
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -104,10 +104,9 @@ impl zkBoostServer {
         shutdown_token: CancellationToken,
     ) -> anyhow::Result<(SocketAddr, Vec<JoinHandle<()>>)> {
         let witness_timeout = Duration::from_secs(self.config.witness_timeout_secs);
-        let proof_timeout = Duration::from_secs(self.config.proof_timeout_secs);
 
         let proof_cache = Arc::new(RwLock::new(LruCache::new(
-            NonZeroUsize::new(self.config.proof_cache_size)
+            NonZeroUsize::new(self.config.proof_cache_size * self.zkvms.len())
                 .expect("proof_cache_size must be non-zero"),
         )));
 
@@ -141,7 +140,6 @@ impl zkBoostServer {
                 worker_input_rx,
                 worker_output_tx.clone(),
                 dashboard_service_tx.clone(),
-                proof_timeout,
             )));
         }
 
@@ -151,7 +149,6 @@ impl zkBoostServer {
             proof_event_tx,
             witness_service_tx,
             dashboard_service_tx.clone(),
-            proof_timeout,
         );
         handles.push(tokio::spawn(proof_service.run(
             shutdown_token.clone(),

--- a/crates/server/tests/integration.rs
+++ b/crates/server/tests/integration.rs
@@ -128,14 +128,12 @@ async fn start_zkboost_server(
     el_endpoint: url::Url,
     zkvm_configs: Vec<zkVMConfig>,
     witness_timeout_secs: u64,
-    proof_timeout_secs: u64,
 ) -> (url::Url, tokio_util::sync::CancellationToken) {
     let config = Config {
         port: 0,
         el_endpoint,
         chain_config_path: None,
         witness_timeout_secs,
-        proof_timeout_secs,
         proof_cache_size: 128,
         witness_cache_size: 128,
         dashboard: DashboardConfig::default(),
@@ -169,22 +167,18 @@ impl TestHarness {
         let fixture = Fixture::load();
         let el_endpoint =
             start_mock_el(&fixture, behavior.witness_timeout, behavior.witness_delay).await;
+        let witness_timeout_secs = if behavior.witness_timeout { 1 } else { 12 };
+        let proof_timeout_secs = if behavior.proof_timeout { 1 } else { 12 };
         let proof_type = ProofType::EthrexZisk;
         let zkvm_config = zkVMConfig::Mock {
             proof_type,
-            mock_proving_time: zkboost_server::config::MockProvingTime::Constant { ms: 3000 },
-            mock_proof_size: 1024,
+            proof_timeout_secs,
+            mock_proving_time: zkboost_server::config::MockProvingTime::Constant { ms: 6000 },
+            mock_proof_size: 128 << 10,
             mock_failure: behavior.proof_failure,
         };
-        let witness_timeout_secs = if behavior.witness_timeout { 1 } else { 12 };
-        let proof_timeout_secs = if behavior.proof_timeout { 1 } else { 12 };
-        let (zkboost_endpoint, shutdown) = start_zkboost_server(
-            el_endpoint,
-            vec![zkvm_config],
-            witness_timeout_secs,
-            proof_timeout_secs,
-        )
-        .await;
+        let (zkboost_endpoint, shutdown) =
+            start_zkboost_server(el_endpoint, vec![zkvm_config], witness_timeout_secs).await;
         let client = zkBoostClient::new(zkboost_endpoint);
         Self {
             client,

--- a/docker/example/mock-zkattestor/zkboost/config.toml
+++ b/docker/example/mock-zkattestor/zkboost/config.toml
@@ -8,10 +8,8 @@ enabled = true
 kind = "mock"
 proof_type = "ethrex-zisk"
 mock_proving_time = { kind = "random", min_ms = 2000, max_ms = 8000 }
-mock_proof_size = 1024
 
 [[zkvm]]
 kind = "mock"
 proof_type = "reth-zisk"
 mock_proving_time = { kind = "random", min_ms = 3000, max_ms = 9000 }
-mock_proof_size = 1024

--- a/docker/example/observability/zkboost/config.toml
+++ b/docker/example/observability/zkboost/config.toml
@@ -8,13 +8,11 @@ enabled = true
 kind = "mock"
 proof_type = "ethrex-zisk"
 mock_proving_time = { kind = "random", min_ms = 2000, max_ms = 8000 }
-mock_proof_size = 1024
 
 [[zkvm]]
 kind = "mock"
 proof_type = "reth-zisk"
 mock_proving_time = { kind = "random", min_ms = 3000, max_ms = 9000 }
-mock_proof_size = 1024
 
 [[zkvm]]
 kind = "mock"


### PR DESCRIPTION
- Move `proof_timeout_secs` to `zkvms.*.proof_timeout_secs`
- Set default mock proving time to `6 seconds` to be more practical
- Set default mock proof size to `128 KiB` to be more practical