### PR TITLE
feat(server): in-process verifier-only zkVM backend (kind: verifier)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1052,6 +1052,15 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
@@ -1297,6 +1306,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,7 +1370,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1396,6 +1437,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "compare_fields"
@@ -2145,7 +2195,7 @@ source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f6
 dependencies = [
  "anyhow",
  "auto_impl",
- "bincode",
+ "bincode 2.0.1",
  "ere-codec 0.8.0",
  "ere-verifier-core 0.8.0",
  "indexmap 2.13.0",
@@ -2161,7 +2211,7 @@ source = "git+https://github.com/eth-act/ere?tag=v0.8.1#653b406fa352f4c53161810c
 dependencies = [
  "anyhow",
  "auto_impl",
- "bincode",
+ "bincode 2.0.1",
  "ere-codec 0.8.1",
  "ere-verifier-core 0.8.1",
  "indexmap 2.13.0",
@@ -2185,7 +2235,7 @@ name = "ere-server-client"
 version = "0.8.1"
 source = "git+https://github.com/eth-act/ere?tag=v0.8.1#653b406fa352f4c53161810c4ef078e79ec45b1b"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "ere-prover-core 0.8.1",
  "ere-server-api",
  "opentelemetry",
@@ -2193,6 +2243,14 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "twirp",
+]
+
+[[package]]
+name = "ere-util-build"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.1#653b406fa352f4c53161810c4ef078e79ec45b1b"
+dependencies = [
+ "cargo_metadata",
 ]
 
 [[package]]
@@ -2216,13 +2274,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ere-verifier-zisk"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.1#653b406fa352f4c53161810c4ef078e79ec45b1b"
+dependencies = [
+ "bincode 2.0.1",
+ "bytemuck",
+ "ere-util-build",
+ "ere-verifier-core 0.8.1",
+ "proofman-util",
+ "proofman-verifier",
+ "serde",
+ "serde-big-array",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2673,6 +2747,17 @@ dependencies = [
  "bitvec",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "fields"
+version = "0.16.1"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.16.1#971209423e8fa53fa32dc747744d68c65aafa6c7"
+dependencies = [
+ "cfg-if",
+ "num-bigint",
+ "paste",
+ "serde",
 ]
 
 [[package]]
@@ -3262,7 +3347,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4091,12 +4176,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4244,10 +4338,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "once_cell"
@@ -4483,7 +4596,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4811,6 +4924,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proofman-util"
+version = "0.16.1"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.16.1#971209423e8fa53fa32dc747744d68c65aafa6c7"
+dependencies = [
+ "bincode 1.3.3",
+ "bytemuck",
+ "colored",
+ "serde",
+ "sysinfo",
+]
+
+[[package]]
+name = "proofman-verifier"
+version = "0.16.1"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.16.1#971209423e8fa53fa32dc747744d68c65aafa6c7"
+dependencies = [
+ "bytemuck",
+ "fields",
+ "proofman-util",
+ "rayon",
+ "tracing",
+]
+
+[[package]]
 name = "proptest"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4846,7 +4983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5960,7 +6097,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6181,6 +6318,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "semver-parser"
@@ -6199,6 +6340,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6615,7 +6765,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "anyhow",
- "bincode",
+ "bincode 2.0.1",
  "ere-prover-core 0.8.0",
  "guest",
  "once_cell",
@@ -6750,6 +6900,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6786,7 +6950,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7746,6 +7910,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7753,9 +7952,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -7782,9 +7992,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-registry"
@@ -7792,9 +8018,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7803,7 +8038,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7812,7 +8056,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7848,7 +8092,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7873,7 +8117,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -7882,6 +8126,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -8252,6 +8505,8 @@ dependencies = [
  "bytes",
  "clap",
  "ere-server-client",
+ "ere-verifier-core 0.8.1",
+ "ere-verifier-zisk",
  "futures",
  "lru 0.12.5",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,8 @@ stateless = { git = "https://github.com/paradigmxyz/stateless", rev = "ed189a519
 
 # ere
 ere-server-client = { git = "https://github.com/eth-act/ere", tag = "v0.8.1" }
+ere-verifier-core = { git = "https://github.com/eth-act/ere", tag = "v0.8.1" }
+ere-verifier-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.8.1" }
 
 # ere-guests
 ere-guests-stateless-validator-common = { git = "https://github.com/eth-act/ere-guests", tag = "v0.9.0", package = "stateless-validator-common" }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/bin/zkboost.rs"
 workspace = true
 
 [features]
-default = []
+default = ["verifier-zisk"]
 otel = [
     "dep:opentelemetry",
     "dep:opentelemetry-otlp",
@@ -21,6 +21,7 @@ otel = [
     "dep:tracing-opentelemetry",
     "ere-server-client/otel",
 ]
+verifier-zisk = ["dep:ere-verifier-core", "dep:ere-verifier-zisk"]
 
 [dependencies]
 anyhow.workspace = true
@@ -65,6 +66,8 @@ stateless.workspace = true
 
 # ere
 ere-server-client.workspace = true
+ere-verifier-core = { workspace = true, optional = true }
+ere-verifier-zisk = { workspace = true, optional = true }
 
 # ere-guests
 ere-guests-stateless-validator-common.workspace = true

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -125,6 +125,12 @@ impl Config {
                         "proof_timeout_secs must be > 0 for {proof_type}"
                     );
                 }
+                zkVMConfig::Verifier { program_vk_url, .. } => {
+                    ensure!(
+                        !program_vk_url.is_empty(),
+                        "program_vk_url must be set for verifier-only zkvm {proof_type}"
+                    );
+                }
             }
             if let zkVMConfig::Mock {
                 mock_proving_time,
@@ -168,7 +174,8 @@ pub enum MockProvingTime {
     },
 }
 
-/// zkVM backend configuration, either a remote ere-server or a mock for testing.
+/// zkVM backend configuration, either a remote ere-server, a mock, or an
+/// in-process verifier-only backend (no proving).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 #[allow(non_camel_case_types)]
@@ -200,13 +207,26 @@ pub enum zkVMConfig {
         #[serde(default)]
         mock_failure: bool,
     },
+    /// In-process verifier-only backend. Verifies proofs received via HTTP
+    /// without running an `ere-server` or pre-loading prover circuits.
+    /// Returns an error on prove requests.
+    Verifier {
+        /// Proof type.
+        proof_type: ProofType,
+        /// URL or local path to the program verifying key file (.vk) for the
+        /// guest program of this proof type. Pre-computed and shipped in
+        /// `eth-act/ere-guests` releases alongside the .elf.
+        program_vk_url: String,
+    },
 }
 
 impl zkVMConfig {
     /// Returns the proof type identifier for this configuration.
     pub fn proof_type(&self) -> ProofType {
         match self {
-            Self::Ere { proof_type, .. } | Self::Mock { proof_type, .. } => *proof_type,
+            Self::Ere { proof_type, .. }
+            | Self::Mock { proof_type, .. }
+            | Self::Verifier { proof_type, .. } => *proof_type,
         }
     }
 }

--- a/crates/server/src/proof.rs
+++ b/crates/server/src/proof.rs
@@ -2,6 +2,7 @@
 //! (dispatched to per-zkVM worker), and completed (cached in LRU, broadcast via SSE).
 
 pub mod input;
+pub mod verifier;
 pub mod worker;
 pub mod zkvm;
 

--- a/crates/server/src/proof/verifier.rs
+++ b/crates/server/src/proof/verifier.rs
@@ -6,10 +6,9 @@
 //! `program_vk`, downloaded from the URL configured for that proof_type.
 
 use anyhow::Context;
-use zkboost_types::ProofType;
-
 #[cfg(feature = "verifier-zisk")]
 use ere_verifier_core::{PublicValues, codec::Decode, zkVMVerifier};
+use zkboost_types::ProofType;
 
 /// Per-zkVM verifier dispatch. Variants are feature-gated.
 #[allow(non_camel_case_types)]
@@ -71,15 +70,11 @@ impl DynVerifier {
 }
 
 async fn download_program_vk(url: &str) -> anyhow::Result<Vec<u8>> {
-    if let Some(path) = url.strip_prefix("file://").or_else(|| {
-        if url.contains("://") {
-            None
-        } else {
-            Some(url)
-        }
-    }) {
-        return std::fs::read(path)
-            .with_context(|| format!("read program_vk from {path}"));
+    if let Some(path) = url
+        .strip_prefix("file://")
+        .or_else(|| if url.contains("://") { None } else { Some(url) })
+    {
+        return std::fs::read(path).with_context(|| format!("read program_vk from {path}"));
     }
     let bytes = reqwest::get(url)
         .await

--- a/crates/server/src/proof/verifier.rs
+++ b/crates/server/src/proof/verifier.rs
@@ -1,0 +1,94 @@
+//! In-process verifier-only backends.
+//!
+//! Wraps the per-zkVM `ere-verifier-*` crates so zkboost can verify proofs
+//! without a remote `ere-server` (which loads the full prover circuit). Each
+//! verifier is bound to a specific compiled guest program via its
+//! `program_vk`, downloaded from the URL configured for that proof_type.
+
+use anyhow::Context;
+use zkboost_types::ProofType;
+
+#[cfg(feature = "verifier-zisk")]
+use ere_verifier_core::{PublicValues, codec::Decode, zkVMVerifier};
+
+/// Per-zkVM verifier dispatch. Variants are feature-gated.
+#[allow(non_camel_case_types)]
+pub(crate) enum DynVerifier {
+    /// In-process ZisK verifier.
+    #[cfg(feature = "verifier-zisk")]
+    Zisk(ere_verifier_zisk::ZiskVerifier),
+}
+
+impl std::fmt::Debug for DynVerifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            #[cfg(feature = "verifier-zisk")]
+            Self::Zisk(_) => f.write_str("DynVerifier::Zisk"),
+            #[cfg(not(any(feature = "verifier-zisk")))]
+            _ => f.write_str("DynVerifier::<empty>"),
+        }
+    }
+}
+
+impl DynVerifier {
+    /// Construct a verifier for the given proof_type by downloading the
+    /// program verifying key from `url` and decoding it.
+    pub(crate) async fn from_url(proof_type: ProofType, url: &str) -> anyhow::Result<Self> {
+        let bytes = download_program_vk(url).await?;
+        Self::from_bytes(proof_type, &bytes)
+    }
+
+    fn from_bytes(proof_type: ProofType, bytes: &[u8]) -> anyhow::Result<Self> {
+        match proof_type {
+            #[cfg(feature = "verifier-zisk")]
+            ProofType::EthrexZisk | ProofType::RethZisk => {
+                let program_vk = ere_verifier_zisk::ZiskProgramVk::decode_from_slice(bytes)
+                    .with_context(|| format!("decode ZiskProgramVk for {proof_type}"))?;
+                Ok(Self::Zisk(ere_verifier_zisk::ZiskVerifier::new(program_vk)))
+            }
+            #[allow(unreachable_patterns)]
+            _ => anyhow::bail!(
+                "no in-process verifier compiled in for proof_type {proof_type}; \
+                 enable the matching `verifier-*` feature on `zkboost-server`"
+            ),
+        }
+    }
+
+    /// Verify a serialized proof and return its public values.
+    pub(crate) async fn verify(&self, proof: &[u8]) -> anyhow::Result<Vec<u8>> {
+        match self {
+            #[cfg(feature = "verifier-zisk")]
+            Self::Zisk(verifier) => {
+                let proof = ere_verifier_zisk::ZiskProof::decode_from_slice(proof)
+                    .context("decode ZiskProof")?;
+                let public_values: PublicValues = verifier
+                    .verify(&proof)
+                    .map_err(|error| anyhow::anyhow!("zisk verify failed: {error}"))?;
+                Ok(Vec::<u8>::from(public_values))
+            }
+        }
+    }
+}
+
+async fn download_program_vk(url: &str) -> anyhow::Result<Vec<u8>> {
+    if let Some(path) = url.strip_prefix("file://").or_else(|| {
+        if url.contains("://") {
+            None
+        } else {
+            Some(url)
+        }
+    }) {
+        return std::fs::read(path)
+            .with_context(|| format!("read program_vk from {path}"));
+    }
+    let bytes = reqwest::get(url)
+        .await
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("status from {url}"))?
+        .bytes()
+        .await
+        .with_context(|| format!("body from {url}"))?
+        .to_vec();
+    Ok(bytes)
+}

--- a/crates/server/src/proof/zkvm.rs
+++ b/crates/server/src/proof/zkvm.rs
@@ -24,7 +24,7 @@ use zkboost_types::{ElKind, Hash256, ProofType};
 
 use crate::{
     config::{MockProvingTime, zkVMConfig},
-    proof::input::NewPayloadRequestWithWitness,
+    proof::{input::NewPayloadRequestWithWitness, verifier::DynVerifier},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -38,7 +38,7 @@ pub(crate) enum zkVMError {
     PublicValuesMismatch,
 }
 
-/// zkVM instance, either a remote ere-server or a mock.
+/// zkVM instance: remote ere-server, in-process mock, or in-process verifier-only.
 #[allow(non_camel_case_types)]
 #[derive(Clone, Debug)]
 pub(crate) enum zkVMInstance {
@@ -59,6 +59,15 @@ pub(crate) enum zkVMInstance {
         proof_timeout: Duration,
         /// Mock zkVM implementation.
         vm: MockzkVM,
+    },
+    /// In-process verifier-only backend. No `ere-server`, no prover circuit
+    /// loaded — just the lightweight `ere-verifier-*` for this proof type.
+    /// Returns an error on prove requests.
+    Verifier {
+        /// Proof type identifier.
+        proof_type: ProofType,
+        /// Verifier implementation, dispatched per proof_type.
+        verifier: Arc<DynVerifier>,
     },
 }
 
@@ -106,6 +115,20 @@ impl zkVMInstance {
                     *mock_failure,
                 ),
             }),
+            zkVMConfig::Verifier {
+                proof_type,
+                program_vk_url,
+            } => {
+                let verifier = DynVerifier::from_url(*proof_type, program_vk_url)
+                    .await
+                    .with_context(|| {
+                        format!("init in-process verifier for {proof_type} from {program_vk_url}")
+                    })?;
+                Ok(Self::Verifier {
+                    proof_type: *proof_type,
+                    verifier: Arc::new(verifier),
+                })
+            }
         }
     }
 
@@ -119,6 +142,9 @@ impl zkVMInstance {
                 .prove(new_payload_request_with_witness.stateless_input())
                 .await;
         }
+        if let Self::Verifier { proof_type, .. } = self {
+            anyhow::bail!("prove not supported for verifier-only zkvm {proof_type}");
+        }
 
         let el_kind = self.proof_type().el_kind();
         let input = new_payload_request_with_witness.to_zkvm_input(el_kind)?;
@@ -127,7 +153,7 @@ impl zkVMInstance {
                 let (_, proof, _) = client.prove(input).await?;
                 Ok(proof.0)
             }
-            Self::Mock { .. } => unreachable!(),
+            Self::Mock { .. } | Self::Verifier { .. } => unreachable!(),
         }
     }
 
@@ -137,7 +163,7 @@ impl zkVMInstance {
         new_payload_request_root: Hash256,
         proof: Vec<u8>,
     ) -> Result<(), zkVMError> {
-        let public_values = match self {
+        let public_values: PublicValues = match self {
             Self::Ere { client, .. } => client
                 .verify(EncodedProof(proof))
                 .await
@@ -145,6 +171,11 @@ impl zkVMInstance {
             Self::Mock { vm, .. } => vm
                 .verify(&proof)
                 .await
+                .map_err(|error| zkVMError::VerificationFailed(error.to_string())),
+            Self::Verifier { verifier, .. } => verifier
+                .verify(&proof)
+                .await
+                .map(PublicValues::from)
                 .map_err(|error| zkVMError::VerificationFailed(error.to_string())),
         }?;
 
@@ -166,14 +197,19 @@ impl zkVMInstance {
     /// Returns the proof type identifier for this instance.
     pub(crate) fn proof_type(&self) -> ProofType {
         match self {
-            Self::Ere { proof_type, .. } | Self::Mock { proof_type, .. } => *proof_type,
+            Self::Ere { proof_type, .. }
+            | Self::Mock { proof_type, .. }
+            | Self::Verifier { proof_type, .. } => *proof_type,
         }
     }
 
     /// Returns the proof timeout for this instance.
+    /// Verifier-only backends never prove, so the timeout is irrelevant — we
+    /// return the default to keep the signature uniform.
     pub(crate) fn proof_timeout(&self) -> Duration {
         match self {
             Self::Ere { proof_timeout, .. } | Self::Mock { proof_timeout, .. } => *proof_timeout,
+            Self::Verifier { .. } => Duration::from_secs(12),
         }
     }
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -132,6 +132,11 @@ impl zkBoostServer {
 
         let mut worker_input_txs = HashMap::new();
         for zkvm in self.zkvms.values() {
+            // Verifier-only backends don't prove, so they get no worker. Prove
+            // requests for those proof_types are dropped at the dispatch layer.
+            if matches!(zkvm, zkVMInstance::Verifier { .. }) {
+                continue;
+            }
             let (worker_input_tx, worker_input_rx) = mpsc::channel(CHANNEL_CAPACITY);
             worker_input_txs.insert(zkvm.proof_type(), worker_input_tx);
             handles.push(tokio::spawn(worker::run_worker(


### PR DESCRIPTION
## Summary

Adds a new `kind: verifier` to `zkVMConfig`: zkboost links the lightweight `ere-verifier-*` crate in-process and verifies proofs without spinning up an `ere-server`. The verifying key (`.vk`) is downloaded at startup from `program_vk_url` (HTTP or `file://`); pre-computed `.vk` files are shipped alongside `.elf` files in `eth-act/ere-guests` releases since v0.9.0.

This separates the prove and verify code paths in zkboost. A node that only needs to verify proofs (e.g. a beacon node receiving `execution_proof` gossip but not generating proofs locally) no longer needs to spin up a per-proof-type `ere-server` — eliminating the GB-scale prover circuit allocation, GPU pinning, and 24+ GB Docker image footprint.

## Motivation

`ere-server` is monolithic and prover-first (`ere/crates/server/cli/src/main.rs:142-159`): its only entry point is `construct_zkvm(elf, resource)` which always builds a `zkVMProver`, regardless of `ProverResource::{Cpu, Gpu, Cluster}`. zkboost forwards both `prove` and `verify` HTTP calls to ere-server (`crates/server/src/proof/zkvm.rs:135-149`), so even a node that only needs to verify gossiped proofs ends up running the full prover stack.

In a kurtosis devnet measured on an RTX PRO 6000 Blackwell rig (1626 blocks proven, 3252 proofs verified):

| Resource | ere-server (prove + verify) | in-process verifier |
|---|---|---|
| Per-op time | 6.37 s/proof | **5.6 ms/verify** |
| Container RAM | 54 GiB | **11 MiB** |
| GPU VRAM | 96 GiB | **0** |
| Image size | 24.4 GB | **180 MB** (zkboost only) |

The EIP-8025 spec (`consensus-specs/specs/_features/eip8025/p2p-interface.md`) treats `proof_types` as a per-node *dynamic capability advertisement* — every aware node receives every type via gossip and verifies whatever its verifier code can handle. Verification is intended to be light. Today's monolithic ere-server forces the heavy prover footprint onto every node that wants to verify, which is the gap this PR closes.

## Changes

- `Cargo.toml`: add `ere-verifier-core`, `ere-verifier-zisk` workspace deps pinned to `ere v0.8.1` (matching the existing `ere-server-client` pin).
- `crates/server/Cargo.toml`: optional deps + `verifier-zisk` feature, included in `default`. Adding more zkVMs is a feature-flag addition.
- `crates/server/src/config.rs`: new `zkVMConfig::Verifier { proof_type, program_vk_url }` variant.
- `crates/server/src/proof/verifier.rs` (new): `DynVerifier` enum, feature-gated per zkVM. Constructed from `program_vk_url`, dispatches `verify` to `ere-verifier-{kind}::Verifier`.
- `crates/server/src/proof/zkvm.rs`: new `zkVMInstance::Verifier` variant; `prove` returns `prove not supported for verifier-only zkvm`; `verify` dispatches in-process via `DynVerifier`.
- `crates/server/src/server.rs`: skip per-zkVM prover worker for `Verifier` variants (no proving, no worker).

## Configuration

```toml
[[zkvm]]
kind = "verifier"
proof_type = "reth-zisk"
program_vk_url = "https://github.com/eth-act/ere-guests/releases/download/v0.9.0/stateless-validator-reth-zisk.vk"
```

`program_vk_url` accepts `https://`, `http://`, or `file://`. The bytes are decoded via `ere_verifier_*::ProgramVk::decode_from_slice` — a 32-byte `ZiskProgramVk` for ZisK.

## Test plan

E2E demo on a kurtosis enclave with two zkboost instances:
- `zkboost-prover`: `kind: ere` → `ere-server-reth-zisk` on GPU 0
- `zkboost-verifier`: `kind: verifier` for `reth-zisk`, **no ere-server**

Same proof type both sides. CL-1 generates and gossips signed proofs; CL-2 receives via gossip, calls `zkboost-verifier`'s `POST /v1/execution_proof_verifications`. Confirmed by `zkboost_verify_total{proof_type="reth-zisk",verified="true"} 3252` on the verifier and zero ere-server containers on the verifier side.

Launcher and test config: ethpandaops/ethereum-package companion PR: ethpandaops/ethereum-package#1385

## Follow-ups (not in this PR)

- Add other zkVM verifier features: `verifier-sp1`, `verifier-risc0`, `verifier-openvm`, `verifier-airbender`. Each is a small feature-flag + match-arm change once `ere-verifier-{kind}` is plumbed.
- Lighthouse-side: today's `--proof-types` flag forces both BN gossip subscription AND VC prove-attempt. The VC will hit zkboost's prove path even for a verifier-only deployment. zkboost correctly returns `prove not supported for verifier-only zkvm`, so this is a Lighthouse-side flag separation, not a zkboost issue, but worth flagging.