### PR TITLE
Add proof types endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The following endpoints are available:
 | `GET`  | `/v1/execution_proof_requests?new_payload_request_root=`       | SSE stream of proof result                                    |
 | `GET`  | `/v1/execution_proofs/{new_payload_request_root}/{proof_type}` | Fetch a completed proof                                       |
 | `POST` | `/v1/execution_proof_verifications`                            | Verify a proof                                                |
+| `GET`  | `/v1/proof_types`                                              | List configured proof types and capabilities                  |
 | `GET`  | `/health`                                                      | Health check                                                  |
 | `GET`  | `/metrics`                                                     | Prometheus metrics                                            |
 

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -83,6 +83,7 @@ pub(crate) fn router(state: Arc<AppState>) -> Router {
             "/v1/execution_proof_verifications",
             post(v1::post_execution_proof_verifications),
         )
+        .route("/v1/proof_types", get(v1::get_proof_types))
         .fallback(fallback_handler)
         .layer(api_middleware);
 

--- a/crates/server/src/http/v1.rs
+++ b/crates/server/src/http/v1.rs
@@ -4,6 +4,7 @@
 //! - `GET /execution_proof_requests` (SSE)
 //! - `GET /execution_proofs/{new_payload_request_root}/{type}`
 //! - `POST /execution_proof_verifications`
+//! - `GET /proof_types`
 
 use axum::{
     Json,
@@ -15,11 +16,13 @@ use serde::de::DeserializeOwned;
 
 mod get_execution_proof_requests;
 mod get_execution_proofs;
+mod get_proof_types;
 mod post_execution_proof_requests;
 mod post_execution_proof_verifications;
 
 pub(crate) use get_execution_proof_requests::get_execution_proof_requests;
 pub(crate) use get_execution_proofs::get_execution_proofs;
+pub(crate) use get_proof_types::get_proof_types;
 pub(crate) use post_execution_proof_requests::post_execution_proof_requests;
 pub(crate) use post_execution_proof_verifications::post_execution_proof_verifications;
 

--- a/crates/server/src/http/v1/get_proof_types.rs
+++ b/crates/server/src/http/v1/get_proof_types.rs
@@ -1,0 +1,126 @@
+//! Handler for `GET /v1/proof_types`.
+
+use std::sync::Arc;
+
+use axum::{Json, extract::State, response::IntoResponse};
+use tracing::instrument;
+use zkboost_types::{ProofTypeInfo, ProofTypesResponse};
+
+use super::ErrorResponse;
+use crate::http::AppState;
+
+/// Returns the list of initialized proof types with their capabilities.
+#[instrument(skip_all)]
+pub(crate) async fn get_proof_types(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, ErrorResponse> {
+    let mut proof_types: Vec<ProofTypeInfo> = state
+        .zkvms
+        .iter()
+        .map(|(proof_type, instance)| {
+            let (kind, can_prove, can_verify) = instance.backend_capabilities();
+            ProofTypeInfo {
+                proof_type: *proof_type,
+                kind,
+                can_prove,
+                can_verify,
+            }
+        })
+        .collect();
+
+    // Sort by proof_type for deterministic response order.
+    proof_types.sort_by_key(|info| info.proof_type);
+
+    Ok(Json(ProofTypesResponse { proof_types }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::{
+        Router,
+        body::{Body, to_bytes},
+        http::Request,
+        routing::get,
+    };
+    use tower::ServiceExt;
+    use zkboost_types::{BackendKind, ProofType, ProofTypesResponse};
+
+    use crate::http::{AppState, v1::get_proof_types};
+
+    fn test_router(state: Arc<AppState>) -> Router {
+        Router::new()
+            .route("/v1/proof_types", get(get_proof_types))
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn test_proof_types_returns_configured_backends() {
+        // mock_app_state() creates one RethZisk mock backend
+        let state = crate::http::tests::mock_app_state().await;
+
+        let response = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/proof_types")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 200);
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(content_type.contains("application/json"));
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let response: ProofTypesResponse = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(response.proof_types.len(), 1);
+
+        let info = &response.proof_types[0];
+        assert_eq!(info.proof_type, ProofType::RethZisk);
+        assert_eq!(info.kind, BackendKind::Mock);
+        assert!(info.can_prove);
+        assert!(info.can_verify);
+    }
+
+    #[tokio::test]
+    async fn test_proof_types_json_field_names() {
+        let state = crate::http::tests::mock_app_state().await;
+
+        let response = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/proof_types")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        // Assert exact JSON field names for serialization stability
+        assert!(json.get("proof_types").is_some());
+        let proof_types = json["proof_types"].as_array().unwrap();
+        assert!(!proof_types.is_empty());
+
+        let first = &proof_types[0];
+        assert!(first.get("proof_type").is_some());
+        assert!(first.get("kind").is_some());
+        assert!(first.get("can_prove").is_some());
+        assert!(first.get("can_verify").is_some());
+
+        // Assert kind serializes to lowercase string
+        assert_eq!(first["kind"], "mock");
+    }
+}

--- a/crates/server/src/proof/zkvm.rs
+++ b/crates/server/src/proof/zkvm.rs
@@ -337,6 +337,7 @@ pub(crate) fn expected_public_values(
 mod tests {
     use std::sync::Arc;
 
+    use ere_verifier::{Verifier, zkVMKind};
     use zkboost_types::{BackendKind, ProofType};
 
     use super::*;
@@ -366,6 +367,14 @@ mod tests {
         }
     }
 
+    /// Creates a test Verifier instance.
+    fn test_verifier_instance() -> zkVMInstance {
+        zkVMInstance::Verifier {
+            proof_type: ProofType::RethZisk,
+            verifier: Arc::new(Verifier::new(zkVMKind::Zisk, &[0; 32]).unwrap()),
+        }
+    }
+
     #[test]
     fn test_ere_backend_capabilities() {
         let instance = test_ere_instance();
@@ -386,10 +395,13 @@ mod tests {
         assert!(can_verify, "mock backends can verify");
     }
 
-    // Note: zkVMInstance::Verifier is not directly tested here because
-    // constructing a Verifier requires a valid program VK file. However:
-    // 1. The match in backend_capabilities() is exhaustive - compiler enforces all variants
-    // 2. The logic is trivial (just returning constants)
-    // 3. The capability mapping (can_prove=false, can_verify=true) is documented in REQUIREMENTS.md
-    // 4. Integration tests with real Verifier instances provide full coverage
+    #[test]
+    fn test_verifier_backend_capabilities() {
+        let instance = test_verifier_instance();
+        let (kind, can_prove, can_verify) = instance.backend_capabilities();
+
+        assert_eq!(kind, BackendKind::Verifier);
+        assert!(!can_prove, "verifier backends can not prove");
+        assert!(can_verify, "verifier backends can verify");
+    }
 }

--- a/crates/server/src/proof/zkvm.rs
+++ b/crates/server/src/proof/zkvm.rs
@@ -209,6 +209,19 @@ impl zkVMInstance {
             Self::Verifier { .. } => Duration::from_secs(12),
         }
     }
+
+    /// Returns the backend kind and capabilities for this instance.
+    ///
+    /// - `Ere`: can prove and verify (remote prover)
+    /// - `Mock`: can prove and verify (testing)
+    /// - `Verifier`: can only verify (no proving circuit loaded)
+    pub(crate) fn backend_capabilities(&self) -> (zkboost_types::BackendKind, bool, bool) {
+        match self {
+            Self::Ere { .. } => (zkboost_types::BackendKind::Ere, true, true),
+            Self::Mock { .. } => (zkboost_types::BackendKind::Mock, true, true),
+            Self::Verifier { .. } => (zkboost_types::BackendKind::Verifier, false, true),
+        }
+    }
 }
 
 /// Mock zkVM for testing.
@@ -318,4 +331,65 @@ pub(crate) fn expected_public_values(
     let output = StatelessValidatorOutput::new(new_payload_request_root.0, true);
     let serialized = output.encode_to_vec()?;
     Ok(Sha256::digest(serialized).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use zkboost_types::{BackendKind, ProofType};
+
+    use super::*;
+
+    /// Creates a test Ere instance with dummy client.
+    fn test_ere_instance() -> zkVMInstance {
+        let endpoint = Url::parse("http://localhost:9999").unwrap();
+        let client = zkVMClient::new(endpoint, reqwest::Client::new(), vec![]).unwrap();
+        zkVMInstance::Ere {
+            proof_type: ProofType::RethZisk,
+            proof_timeout: Duration::from_secs(10),
+            client: Arc::new(client),
+        }
+    }
+
+    /// Creates a test Mock instance.
+    fn test_mock_instance() -> zkVMInstance {
+        zkVMInstance::Mock {
+            proof_type: ProofType::RethZisk,
+            proof_timeout: Duration::from_secs(10),
+            vm: MockzkVM::new(
+                zkboost_types::ElKind::Reth,
+                crate::config::MockProvingTime::Constant { ms: 10 },
+                64,
+                false,
+            ),
+        }
+    }
+
+    #[test]
+    fn test_ere_backend_capabilities() {
+        let instance = test_ere_instance();
+        let (kind, can_prove, can_verify) = instance.backend_capabilities();
+
+        assert_eq!(kind, BackendKind::Ere);
+        assert!(can_prove, "ere backends can prove");
+        assert!(can_verify, "ere backends can verify");
+    }
+
+    #[test]
+    fn test_mock_backend_capabilities() {
+        let instance = test_mock_instance();
+        let (kind, can_prove, can_verify) = instance.backend_capabilities();
+
+        assert_eq!(kind, BackendKind::Mock);
+        assert!(can_prove, "mock backends can prove");
+        assert!(can_verify, "mock backends can verify");
+    }
+
+    // Note: zkVMInstance::Verifier is not directly tested here because
+    // constructing a Verifier requires a valid program VK file. However:
+    // 1. The match in backend_capabilities() is exhaustive - compiler enforces all variants
+    // 2. The logic is trivial (just returning constants)
+    // 3. The capability mapping (can_prove=false, can_verify=true) is documented in REQUIREMENTS.md
+    // 4. Integration tests with real Verifier instances provide full coverage
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -75,6 +75,40 @@ pub enum ProofStatus {
     Invalid,
 }
 
+/// Response for `GET /v1/proof_types`.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProofTypesResponse {
+    /// List of initialized proof types with their capabilities.
+    pub proof_types: Vec<ProofTypeInfo>,
+}
+
+/// Information about a single initialized proof type.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProofTypeInfo {
+    /// The proof type identifier (e.g., "reth-zisk").
+    pub proof_type: ProofType,
+    /// The backend kind: "ere", "mock", or "verifier".
+    pub kind: BackendKind,
+    /// Whether this backend can generate proofs.
+    pub can_prove: bool,
+    /// Whether this backend can verify proofs.
+    pub can_verify: bool,
+}
+
+/// Backend kind for a zkVM instance.
+///
+/// Uses the same terminology as zkboost configuration.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BackendKind {
+    /// Remote ere-server backend.
+    Ere,
+    /// In-process mock backend for testing.
+    Mock,
+    /// In-process verifier-only backend.
+    Verifier,
+}
+
 impl ProofStatus {
     /// Returns `true` if proof status is `ProofStatus::Valid`:
     pub fn is_valid(&self) -> bool {
@@ -257,11 +291,55 @@ mod comma_separated {
 
 #[cfg(test)]
 mod tests {
-    use crate::ProofRequestQuery;
+    use crate::{BackendKind, ProofRequestQuery, ProofType, ProofTypeInfo, ProofTypesResponse};
 
     #[test]
     fn test_empty_proof_types_deserializes_to_empty_vec() {
         let query: ProofRequestQuery = serde_json::from_str(r#"{"proof_types": ""}"#).unwrap();
         assert!(query.proof_types.is_empty());
+    }
+
+    #[test]
+    fn test_backend_kind_serialization() {
+        // Verify each BackendKind serializes to the expected lowercase string
+        assert_eq!(
+            serde_json::to_string(&BackendKind::Ere).unwrap(),
+            r#""ere""#
+        );
+        assert_eq!(
+            serde_json::to_string(&BackendKind::Mock).unwrap(),
+            r#""mock""#
+        );
+        assert_eq!(
+            serde_json::to_string(&BackendKind::Verifier).unwrap(),
+            r#""verifier""#
+        );
+    }
+
+    #[test]
+    fn test_proof_types_response_roundtrip() {
+        // Verify the response type serializes and deserializes correctly
+        let response = ProofTypesResponse {
+            proof_types: vec![
+                ProofTypeInfo {
+                    proof_type: ProofType::RethZisk,
+                    kind: BackendKind::Ere,
+                    can_prove: true,
+                    can_verify: true,
+                },
+                ProofTypeInfo {
+                    proof_type: ProofType::EthrexZisk,
+                    kind: BackendKind::Verifier,
+                    can_prove: false,
+                    can_verify: true,
+                },
+            ],
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        let parsed: ProofTypesResponse = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(response, parsed);
+        assert_eq!(parsed.proof_types.len(), 2);
     }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -266,6 +266,41 @@
                     }
                 }
             }
+        },
+        "/v1/proof_types": {
+            "get": {
+                "operationId": "getProofTypes",
+                "summary": "List configured proof types and their capabilities",
+                "description": "Returns the list of proof types initialized on this server, along with their backend kind and capabilities (can_prove, can_verify). Useful for discovering what proof types are available before submitting requests.",
+                "responses": {
+                    "200": {
+                        "description": "List of configured proof types.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProofTypesResponse"
+                                },
+                                "example": {
+                                    "proof_types": [
+                                        {
+                                            "proof_type": "reth-sp1",
+                                            "kind": "ere",
+                                            "can_prove": true,
+                                            "can_verify": true
+                                        },
+                                        {
+                                            "proof_type": "reth-zisk",
+                                            "kind": "verifier",
+                                            "can_prove": false,
+                                            "can_verify": true
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -393,6 +428,57 @@
                     }
                 },
                 "description": "SSE event payload for `proof_failure`."
+            },
+            "BackendKind": {
+                "type": "string",
+                "enum": [
+                    "ere",
+                    "mock",
+                    "verifier"
+                ],
+                "description": "Backend kind for a zkVM instance. ere: remote ere-server backend. mock: in-process mock backend for testing. verifier: in-process verifier-only backend (cannot prove)."
+            },
+            "ProofTypeInfo": {
+                "type": "object",
+                "required": [
+                    "proof_type",
+                    "kind",
+                    "can_prove",
+                    "can_verify"
+                ],
+                "properties": {
+                    "proof_type": {
+                        "$ref": "#/components/schemas/ProofType"
+                    },
+                    "kind": {
+                        "$ref": "#/components/schemas/BackendKind"
+                    },
+                    "can_prove": {
+                        "type": "boolean",
+                        "description": "Whether this backend can generate proofs."
+                    },
+                    "can_verify": {
+                        "type": "boolean",
+                        "description": "Whether this backend can verify proofs."
+                    }
+                },
+                "description": "Information about a single initialized proof type."
+            },
+            "ProofTypesResponse": {
+                "type": "object",
+                "required": [
+                    "proof_types"
+                ],
+                "properties": {
+                    "proof_types": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ProofTypeInfo"
+                        },
+                        "description": "List of initialized proof types, sorted by proof_type."
+                    }
+                },
+                "description": "Response for GET /v1/proof_types."
             }
         }
     }


### PR DESCRIPTION
## Summary
  - Add `GET /v1/proof_types` endpoint that returns configured proof types with their backend
  kind and capabilities (can_prove, can_verify)
  - Enables Assertoor and other tooling to discover server capabilities before running tests

  ## Test plan
  - [x] Unit tests for handler response and JSON field names
  - [x] Unit tests for `backend_capabilities()` on Ere and Mock variants
  - [x] Type serialization tests for `BackendKind` and `ProofTypesResponse`
  - [x] `cargo test --workspace` passes
  - [x] `cargo +nightly fmt --check` passes
  - [x] `cargo clippy` passes

Written with [Claude Code](https://code.claude.com)